### PR TITLE
Improve Import Error Handling for Scraping and Emailing Modules

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,8 +3,13 @@ from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
 from flask_cors import CORS
 
-from scraping.scraper import scrape_links
-from emailing.mail import send_email
+
+try:
+    from .scraping.scraper import scrape_links
+    from .emailing.mail import send_email
+except ImportError:
+    from scraping.scraper import scrape_links
+    from emailing.mail import send_email
 
 from pymongo import MongoClient, errors as PyMongoError
 


### PR DESCRIPTION
- Implement a try-except block to handle ImportError when importing modules.
- Attempt to import with relative paths first, then fallback to absolute paths.
- Ensure compatibility and flexibility in various environments (e.g., local development and production).
- Enhance robustness of the import mechanism, reducing the likelihood of import failures.